### PR TITLE
Propose initial meeting

### DIFF
--- a/meetings/2024-01-31.md
+++ b/meetings/2024-01-31.md
@@ -1,7 +1,7 @@
-## Agenda: Jan XX WASI Observe Video call
+## Agenda: Jan 31 WASI Observe Video call
 
 - **Where**: zoom.us
-- **When**: Jan XX 2024, 16:00-17:00 UTC
+- **When**: Jan 31 2024, 16:00-17:00 UTC
 - **Contact**:
   - Name: Chris Dickinson
   - Email: chris@dylibso.com

--- a/meetings/2024-01-alpha.md
+++ b/meetings/2024-01-alpha.md
@@ -1,0 +1,21 @@
+## Agenda: Jan XX WASI Observe Video call
+
+- **Where**: zoom.us
+- **When**: Jan XX 2024, 16:00-17:00 UTC
+- **Contact**:
+  - Name: Chris Dickinson
+  - Email: chris@dylibso.com
+
+## Logistics
+
+The meeting will be on a zoom.us video conference.
+
+## Agenda items
+
+1. [Chris Dickinson]: Discuss design values and goals, starting from the README; are we aligned?
+1. [Chris Dickinson]: WASI proposal process: what to expect, upcoming dates, Phase 1 presentation & vote, etc.
+1. [Chris Dickinson]: Bookkeeping -- do we want to plan on weekly or fortnightly meetings? Is this time slot okay? Do we want a chat channel someplace?
+
+## Minutes
+
+- To be filled in later


### PR DESCRIPTION
/cc @endocrimes, @Walther, @brooksmtownsend, @squillace

Hi folks! I'd like to meet up in advance of the Feb 8th WASI meeting, at which there will be a vote on moving this proposal to phase 1. It looks like 16:00 UTC might be the best overlap for everyone (that's 8am Portland time, 6pm UTC+2).

I propose we meet up at that time sometime in the next two weeks. I've left the date open for now – any date between Jan 22nd through Feb 2nd is okay!

So! I have two requests:

1. Please let me know which dates work for you! You can either comment here or, if you'd prefer to reach out privately, email me at chris at dylibso dot com.
2. Let me know on this issue if using the email address associated with your GitHub profile is okay, or if you want me to use another email. If you want to keep that email private, please email me (chris at dylibso dot com) from your preferred address.

And if you have suggestions on better ways to do this sort of scheduling, please let me know :smile:

I plan to merge this on Friday with a definite date set, then email invites to the addresses listed on everyone's GitHub profiles. (If another email works better, please comment here that you'll reach out & email me from your preferred address!)

(Apologies for the delay on getting this out, we've had some :sparkles: _interesting weather_ :sparkles: these last few days. I hope everyone affected is staying safe & warm!)

