### PR TITLE
Update REAME with automatic instrumentation user story

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ the telemetry that platform makes available.
 Having considered the telemetry available through the WASI observe tooling, the
 SRE determines that the Wasm component model is an acceptable platform target.
 
+##### A Programmer Wants Automatic Instrumentation Of Their Component
+
+A programmer is having trouble tracking down a problem in their component related
+to imports and exports during development. Without bringing in specific libraries
+to set up spans and trace contexts, they wish to export a trace of each invoked
+export and import during the lifetime of that component.
+
 ### Non-goals
 
 - TKTK


### PR DESCRIPTION
I left this one pretty barebones because we still have a fundamental question to answer: does this belong in `wasi:observe`?

I actually think it doesn't, at least explicitly. The user story that I'm describing here relies on the host side to provide instrumentation of imports and exports, and I don't think we're proposing to change standard interfaces to include a trace context. I thought that this would be a valuable user story to call out when it comes to instrumentation of standard interfaces and custom interfaces.

Thoughts? 😄 